### PR TITLE
Add Devcontainer configs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/universal
+{
+	"name": "Launch Course",
+
+    "dockerComposeFile": [ "docker-compose.yml" ],
+    "service" : "devcontainer",
+    "workspaceFolder": "/workspaces/pl-ucb-csxxx",
+	
+    "forwardPorts": [ 3000 ],
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+    },
+
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/universal
 {
-	"name": "Launch Course",
+    "name": "Launch Course",
 
     "dockerComposeFile": [ "docker-compose.yml" ],
     "service" : "devcontainer",
@@ -9,10 +9,10 @@
 	
     "forwardPorts": [ 3000 ],
 
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	"features": {
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
 
-    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -3,12 +3,12 @@ services:
     image: prairielearn/prairielearn:latest
     platform: linux/amd64
     environment:
-      HOST_JOBS_DIR: /tmp/directory/for/autograder/jobqueue
+      HOST_JOBS_DIR: /tmp/dir-for-ag-jobqueue
     ports:
       - 3000:3000
     volumes:
-      - /tmp/directory/for/autograder/jobqueue:/jobs
-      - .:/course
+      - /tmp/dir-for-ag-jobqueue:/jobs
+      - ..:/course
       - /var/run/docker.sock:/var/run/docker.sock
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  prairielearn:
+    image: prairielearn/prairielearn:latest
+    platform: linux/amd64
+    environment:
+      HOST_JOBS_DIR: /tmp/directory/for/autograder/jobqueue
+    ports:
+      - 3000:3000
+    volumes:
+      - /tmp/directory/for/autograder/jobqueue:/jobs
+      - .:/course
+      - /var/run/docker.sock:/var/run/docker.sock
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/universal
+    platform: linux/amd64
+    links:
+      - prairielearn
+    volumes: # Mount the root folder that contains .git
+      - ..:/workspaces/pl-ucb-csxxx:rw


### PR DESCRIPTION
Added configuration to launch a devcontainer with Prairielearn launched simultaneously. The primary benefit of this is to enable demos/development without installing docker (or even an IDE!) locally -- see "Run in the cloud" below.

Run in the cloud / browser:
<img width="1243" alt="Screenshot 2024-06-12 at 10 58 32 AM" src="https://github.com/ace-lab/pl-ucb-csxxx/assets/31297176/3ccb1a62-6985-4e4f-b321-d49beb8735ad">
1. Click the "Code" dropdown on the page of this branch (will also work on master once merged)
2. Click the "Codespaces" tab
3. Click the "+" to create a new codespace
4. You will be dropped into a VSCode web editor
    - If you prefer your local IDE, then you can connect to the codespace via an extension ([vscode](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) | [intellij](https://plugins.jetbrains.com/plugin/20060-github-codespaces))


Run locally:
0. Have docker installed ([desktop](https://docs.docker.com/desktop/) | [headless](https://docs.docker.com/engine/install/)) and (if you installed docker engine) [your user given docker execution/configuration permissions](https://docs.docker.com/engine/install/linux-postinstall/)
1. Open this repo in your IDE
2. Launch the devcontainer as supported by your IDE
    - VSCode:
        1. Install the Devcontainers extension <img width="921" alt="Screenshot 2024-06-12 at 11 05 03 AM" src="https://github.com/ace-lab/pl-ucb-csxxx/assets/31297176/cc35270d-b75e-4f64-93cf-1a42f6d133c2">
        2. Open the Command Pallet (Ctrl+Shift+P (Windows,Linux) or  Cmd+Shift+P (Mac)) and select "Dev Containers: Reopen in Container" <img width="622" alt="Screenshot 2024-06-12 at 11 07 59 AM" src="https://github.com/ace-lab/pl-ucb-csxxx/assets/31297176/59ebe8a2-3bb9-4e6a-a50e-01d98f2e3270">
        
     - IntelliJ: [see their docs](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html) 
     - Other IDEs will likely require the [devcontainers cli](https://github.com/devcontainers/cli) and a remote (similar to ssh) connection to the started container. This process is rather involved and somewhat unstable as of 12 June 2024. If your IDE supports it, I recommend connecting to a codespace as detailed above ("Run in the cloud").




