### PR TITLE
Add devcontainer details to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,26 @@ branch `main` rather than `master`, **do not do so for PL repos** as
 the server will not be able to sync them.  The server will only sync
 to the `master` branch.
 
+# Developing Prairielearn materials with this repo
+
+We now have a configuration to launch a devcontainer with Prairielearn launched *automatically*! The primary benefit of this is to enable demos/development without installing docker (or even an IDE!) locally -- see "Run in the cloud" below.
+
+### Run in the cloud / browser
+<img width="1243" alt="Screenshot 2024-06-12 at 10 58 32 AM" src="https://github.com/ace-lab/pl-ucb-csxxx/assets/31297176/3ccb1a62-6985-4e4f-b321-d49beb8735ad">
+1. Click the "Code" dropdown on the page of this branch (will also work on master once merged)
+2. Click the "Codespaces" tab
+3. Click the "+" to create a new codespace
+4. You will be dropped into a VSCode web editor
+    - If you prefer your local IDE, then you can connect to the codespace via an extension ([vscode](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces) | [intellij](https://plugins.jetbrains.com/plugin/20060-github-codespaces))
+
+
+### Run locally
+0. Have docker installed ([desktop](https://docs.docker.com/desktop/) | [headless](https://docs.docker.com/engine/install/)) and (if you installed docker engine) [your user given docker execution/configuration permissions](https://docs.docker.com/engine/install/linux-postinstall/)
+1. Open this repo in your IDE
+2. Launch the devcontainer as supported by your IDE
+    - VSCode:
+        1. Install the Devcontainers extension <img width="921" alt="Screenshot 2024-06-12 at 11 05 03 AM" src="https://github.com/ace-lab/pl-ucb-csxxx/assets/31297176/cc35270d-b75e-4f64-93cf-1a42f6d133c2">
+        2. Open the Command Pallet (Ctrl+Shift+P (Windows,Linux) or  Cmd+Shift+P (Mac)) and select "Dev Containers: Reopen in Container" <img width="622" alt="Screenshot 2024-06-12 at 11 07 59 AM" src="https://github.com/ace-lab/pl-ucb-csxxx/assets/31297176/59ebe8a2-3bb9-4e6a-a50e-01d98f2e3270">
+
+     - IntelliJ: [see their docs](https://www.jetbrains.com/help/idea/connect-to-devcontainer.html) 
+     - Other IDEs will likely require the [devcontainers cli](https://github.com/devcontainers/cli) and a remote (similar to ssh) connection to the started container. This process is rather involved and somewhat unstable as of 12 June 2024. If your IDE supports it, I recommend connecting to a codespace as detailed above ("Run in the cloud").


### PR DESCRIPTION
Armando mentioned in meeting today that this should be on the README or the wiki, so I picked the README to make sure it follows forks