### PR TITLE
Use newest version of docker-in-docker (devcontainer)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
+        "ghcr.io/devcontainers/features/docker-outside-of-docker": {}
     },
 
     "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"


### PR DESCRIPTION
As the title suggests, just replace the pinned old version of docker-in-docker with the most recent one